### PR TITLE
0.2/fix-NXBT-3255-allow-to-configure-imagePullSecrets

### DIFF
--- a/nuxeo/Chart.yaml
+++ b/nuxeo/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: nuxeo
-version: 0.2.3
+version: 0.2.4

--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
 {{ toYaml .Values.nuxeo.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.nuxeo.image.pullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.nuxeo.image.pullSecrets }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         resources:

--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -38,7 +38,9 @@ spec:
             memory: "{{ .Values.nuxeo.resources.limits.memory }}"
             cpu: "{{ .Values.nuxeo.resources.limits.cpu }}"
         image: "{{ .Values.nuxeo.image.repository }}:{{ .Values.nuxeo.image.tag }}"
+{{- if .Values.nuxeo.image.pullPolicy }}
         imagePullPolicy: {{ .Values.nuxeo.image.pullPolicy }}
+{{- end}}
         ports:
         - containerPort: {{ .Values.nuxeo.service.internalPort }}
         livenessProbe:

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -2,7 +2,6 @@ nuxeo:
   image:
     repository: nuxeo/nuxeo
     tag: master
-    pullPolicy: Always
   replicaCount: 1
   resources:
     requests:


### PR DESCRIPTION
I didn't take https://github.com/nuxeo/nuxeo-helm-chart/pull/8/commits/02e318732fd22d2171c9b1869e04475632b67584 (ES recovery node setup) because the 0.2.x chart deploys two masters.