### PR TITLE
0.2/nxbt 3292 deploy green elastic without replicas

### DIFF
--- a/nuxeo/Chart.yaml
+++ b/nuxeo/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: nuxeo
-version: 0.2.4
+version: 0.3.0

--- a/nuxeo/templates/configmap.yaml
+++ b/nuxeo/templates/configmap.yaml
@@ -32,6 +32,9 @@ data:
     elasticsearch.clusterName={{ .Values.nuxeo.elasticsearch.clusterName }}
     elasticsearch.addressList=http://{{ .Release.Name }}-elasticsearch-client:9200
     elasticsearch.indexName={{ .Values.nuxeo.elasticsearch.indexName }}
+    elasticsearch.indexNumberOfReplicas={{ .Values.nuxeo.elasticsearch.indexNumberOfReplicas }}
+    elasticsearch.restClient.socketTimeoutMs={{ .Values.nuxeo.elasticsearch.restClient.socketTimeoutMs }}
+    elasticsearch.restClient.connectionTimeoutMs={{ .Values.nuxeo.elasticsearch.restClient.connectionTimeoutMs }}
 {{- end }}
 {{- if or .Values.kafka.deploy .Values.tags.kafka}}
     kafka.enabled=true

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -47,6 +47,10 @@ nuxeo:
     clusterName: elasticsearch
     indexName: nuxeo
     deploy: false
+    indexNumberOfReplicas: 0
+    restClient:
+      socketTimeoutMs: 300000
+      connectionTimeoutMs: 300000
   ingress:
     enabled: false
     annotations:

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -90,6 +90,11 @@ postgresql:
 ## these are for a staging cluster only, but it needs 2 masters anyway
 elasticsearch:
   appVersion: "6.2"
+  cluster:
+    env:
+      MINIMUM_MASTER_NODES: "1"
+      EXPECTED_MASTER_NODES: "1"
+      RECOVER_AFTER_MASTER_NODES: "1"
   serviceAccounts:
     client:
       create: false
@@ -110,7 +115,7 @@ elasticsearch:
         cpu: 25m
         memory: 512Mi
   master:
-    replicas: 2
+    replicas: 1
     persistence:
       enabled: false
     resources:


### PR DESCRIPTION
"Backporting" https://github.com/nuxeo/nuxeo-helm-chart/pull/8 
imagePullPolicy and imagePullSecrets are already taken into account so 2 out of 4 commits didn't need to be backported.