### PR TITLE
0.3/fix nxbt 3298 rollout mongo db with persistency

### DIFF
--- a/nuxeo/requirements.yaml
+++ b/nuxeo/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: mongodb
-    version: ~7.2.9
+    version: ~7.8.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: nuxeo.mongodb.deploy
     alias: mongodb


### PR DESCRIPTION
the mongo chart useStatefulSet value is introduced in version 7.8.0 This is necessary to rollout mongodb with persistency even when there is a version upgrade.