### PR TITLE
NXP-29003: Update 0.x chart for replication tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ nuxeo:
     deploy: true
 ```
 
+### How to Install Dependencies Without Nuxeo
+
+To install some dependency subcharts, e.g. `mongodb` and `elasticsearch`, without installing Nuxeo:
+
+```yaml
+nuxeo:
+  enable: false
+tags:
+  mongodb: true
+  elasticsearch: true
+```
+
+This is useful to run the nuxeo unit tests in an production-like environment.
+
 ## Installing the Chart
 
 If you enable some dependencies, make sure you download the related charts before:
@@ -133,6 +147,17 @@ helm upgrade RELEASE_NAME --set nuxeo.persistence.enabled=true nuxeo
 ```shell
 helm delete --purge RELEASE_NAME
 ```
+
+## Parameters
+
+The following tables lists some of the configurable parameters of this chart and their default values. See [values.yaml](nuxeo/values.yaml) for the complete list.
+
+| Parameter                   | Description                             | Default                                 |
+| --------------------------- | --------------------------------------- | --------------------------------------- |
+| `nuxeo.enable`              | Enable Nuxeo                            | `true`                                  |
+| `nuxeo.image.repository`    | Nuxeo image name                        | `docker.packages.nuxeo.com/nuxeo/nuxeo` |
+| `nuxeo.image.tag`           | Nuxeo image tag                         | `latest`                                |
+| `nuxeo.persistence.enabled` | Enable persistence of binaries and logs | `false`                                 |
 
 ## Using Minikube
 

--- a/nuxeo/templates/backup_cronjob.yaml
+++ b/nuxeo/templates/backup_cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nuxeo.mongodb.backup.enable }}
+{{- if and .Values.nuxeo.enable .Values.nuxeo.mongodb.backup.enable }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:

--- a/nuxeo/templates/configmap.yaml
+++ b/nuxeo/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nuxeo.enable }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -67,3 +68,4 @@ data:
         nuxeoctl register $NUXEO_CONNECT_USERNAME $NUXEO_STUDIO_PROJECT dev helm $NUXEO_CONNECT_PASSWORD
       fi
     fi
+{{- end }}

--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nuxeo.enable }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -129,3 +130,4 @@ spec:
         {{- else }}
         emptyDir: {}
         {{- end }}
+{{- end }}

--- a/nuxeo/templates/ingress.yaml
+++ b/nuxeo/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nuxeo.ingress.enabled -}}
+{{- if and .Values.nuxeo.enabled .Values.nuxeo.ingress.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/nuxeo/templates/pvc.yaml
+++ b/nuxeo/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nuxeo.persistence.enabled }}
+{{- if and .Values.nuxeo.enable .Values.nuxeo.persistence.enabled }}
 {{- if .Values.nuxeo.persistence.size.binaries }}
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/nuxeo/templates/secret.yaml
+++ b/nuxeo/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nuxeo.enable }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -33,4 +34,5 @@ metadata:
 type: Opaque
 stringData:
   CLID: {{ .Values.nuxeo.clid }}
+{{- end }}
 {{- end }}

--- a/nuxeo/templates/service.yaml
+++ b/nuxeo/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nuxeo.enable }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,3 +21,4 @@ spec:
     name: http
   selector:
     app: {{ template "nuxeo.fullname" . }}
+{{- end }}

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -1,4 +1,5 @@
 nuxeo:
+  enable: true
   image:
     repository: nuxeo/nuxeo
     tag: master


### PR DESCRIPTION
To allow installing some dependency subcharts, e.g. mongodb, postgresql, elasticsearch, ..., without installing nuxeo.