### PR TITLE
NXP-29156: Upgrade mongodb chart to bitnami one

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,7 @@ pipeline {
 
                 helm repo add kubernetes-charts https://kubernetes-charts.storage.googleapis.com/
                 helm repo add kubernetes-charts-incubator http://storage.googleapis.com/kubernetes-charts-incubator
+                helm repo add bitnami https://charts.bitnami.com/bitnami
 
                 helm dependency update ${CHART_NAME}
 
@@ -115,7 +116,7 @@ pipeline {
                 jx step helm install ${CHART_NAME} \
                   --name=${TEST_RELEASE} \
                   --namespace=${TEST_NAMESPACE} \
-                  --set=nuxeo.image.tag=11.1-SNAPSHOT # TODO remove when NXP-28504 is done and the latest tag (default) is available
+                  --set=nuxeo.image.tag=11.x # TODO remove when NXP-28504 is done and the latest tag (default) is available
               """
 
               // check deployment status, exits if not OK

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently, there is a single version of this chart for all the versions of Nuxeo
 
 This chart has the following dependencies as subcharts:
 
-- [MongoDB](https://github.com/helm/charts/tree/master/stable/mongodb/values.yaml)
+- [MongoDB](https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml)
 - [Postgresql](https://github.com/helm/charts/tree/master/stable/postgresql/values.yaml)
 - [Elasticsearch](https://github.com/helm/charts/tree/master/stable/elasticsearch/values.yaml)
 - [Kafka/ZooKeeper](https://github.com/helm/charts/tree/master/incubator/kafka/values.yaml)

--- a/nuxeo/requirements.yaml
+++ b/nuxeo/requirements.yaml
@@ -14,8 +14,8 @@ dependencies:
     tags:
       - kafka
   - name: mongodb
-    version: ~7.8.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: ~7.14.2
+    repository: https://charts.bitnami.com/bitnami
     condition: nuxeo.mongodb.deploy
     alias: mongodb
     tags:

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -73,8 +73,10 @@ nuxeo:
 ## Values overridden from the MongoDB chart: https://github.com/helm/charts/blob/master/stable/mongodb/values.yaml
 mongodb:
   image:
-    tag: "4.2.3"
+    tag: "4.2.7"
   usePassword: false
+  serviceAccount:
+    create: false
   persistence:
     enabled: false
   resources:


### PR DESCRIPTION
Upgrade of the Chart is needed due to https://github.com/helm/charts/issues/16450 which has required a fix in the Docker image https://github.com/bitnami/bitnami-docker-mongodb/issues/151.