### PR TITLE
NXBT-3365: Fix Redis host Nuxeo configuration parameter

### DIFF
--- a/nuxeo/templates/configmap.yaml
+++ b/nuxeo/templates/configmap.yaml
@@ -51,7 +51,7 @@ data:
 {{- else }}
     nuxeo.templates=default,redis
 {{- end }}
-    nuxeo.redis.host={{ .Release.Name }}-master
+    nuxeo.redis.host={{ .Release.Name }}-redis-master
     nuxeo.work.queuing=redis
     nuxeo.redis.enabled=true
 {{- end }}


### PR DESCRIPTION
Fix Redis host nuxeo.conf parameter in the configmap, according to the master pod deployed by the Redis chart.