### PR TITLE
Improvement nxbt 3450 metrics worker nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
               kubectl create namespace ${TEST_NAMESPACE}
               helm3 install ${TEST_RELEASE} ${CHART_NAME} \
                 --namespace=${TEST_NAMESPACE} \
-                --set=image.tag=11.x
+                --values=ci/values.yaml
             """
             try {
               // check deployment status, exit if not OK

--- a/ci/values.yaml
+++ b/ci/values.yaml
@@ -1,0 +1,9 @@
+image:
+  tag: "11.x"
+nodeSelector:
+  team: platform
+tolerations:
+- effect: NoSchedule
+  key: team
+  operator: Equal
+  value: platform

--- a/nuxeo/templates/NOTES.txt
+++ b/nuxeo/templates/NOTES.txt
@@ -1,12 +1,15 @@
 
 {{- include "nuxeo.validateValues" . }}
 
+{{- $architecture := include "nuxeo.architecture" . }}
 {{- $persistentVolumeStorage := .Values.persistentVolumeStorage.enabled }}
 {{- $fullname := include "nuxeo.fullname" . }}
 {{- $releaseNamespace := .Release.Namespace }}
 {{- $clusterDomain := .Values.clusterDomain }}
 
 ** Please be patient while the nuxeo chart is being deployed **
+
+Nuxeo architecture: {{ $architecture }}.
 
 {{- if not (include "nuxeo.cloudProvider.enabled" .) }}
 

--- a/nuxeo/templates/_helpers.tpl
+++ b/nuxeo/templates/_helpers.tpl
@@ -42,6 +42,13 @@ Compile all warnings into a single message, and call fail.
 {{- end -}}
 
 {{/*
+Return the Nuxeo architecure, "singleNode" by default.
+*/}}
+{{- define "nuxeo.architecture" -}}
+    {{- default "singleNode" .Values.architecture -}}
+{{- end -}}
+
+{{/*
 Return true if a cloud provider is enabled for binary storage.
 */}}
 {{- define "nuxeo.cloudProvider.enabled" -}}
@@ -156,4 +163,15 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 stringData: {{ .val | nindent 2 }}
+{{- end -}}
+
+{{/*
+Return the list of node types depending on the architecture.
+*/}}
+{{- define "nuxeo.nodeTypes" -}}
+{{- if eq (include "nuxeo.architecture" .) "api-worker" -}}
+    api,worker
+{{- else -}}
+    single
+{{- end -}}
 {{- end -}}

--- a/nuxeo/templates/configmap.yaml
+++ b/nuxeo/templates/configmap.yaml
@@ -18,19 +18,23 @@ data:
     nuxeo.stream.pubsub.log.codec=avro
 {{- if .Values.mongodb.enabled }}
     nuxeo.templates=default,mongodb
-    nuxeo.mongodb.server={{ .Values.mongodb.protocol }}://{{ $credentials }}{{ required "mongodb.host is required" .Values.mongodb.host }}:{{ .Values.mongodb.port }}
+{{- if .Values.mongodb.url }}
+    nuxeo.mongodb.server={{ .Values.mongodb.protocol }}://{{ $credentials }}{{ .Values.mongodb.url }}
+{{- else}}
+    nuxeo.mongodb.server={{ .Values.mongodb.protocol }}://{{ $credentials }}{{ .Values.mongodb.host }}:{{ .Values.mongodb.port }}
+{{- end }}
     nuxeo.mongodb.dbname={{ template "nuxeo.fullname" . }}
 {{- end }}
 {{- if .Values.postgresql.enabled }}
     nuxeo.templates=default,postgresql
-    nuxeo.db.host={{ required "postgresql.host is required" .Values.postgresql.host }}
+    nuxeo.db.host={{ .Values.postgresql.host }}
     nuxeo.db.port={{ .Values.postgresql.port }}
     nuxeo.db.name={{ template "nuxeo.fullname" . }}
     nuxeo.db.user={{ .Values.postgresql.username }}
     nuxeo.db.password={{ .Values.postgresql.password }}
 {{- end }}
 {{- if .Values.elasticsearch.enabled }}
-    elasticsearch.addressList={{ .Values.elasticsearch.protocol }}://{{ required "elasticsearch.host is required" .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}
+    elasticsearch.addressList={{ .Values.elasticsearch.protocol }}://{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port }}
     elasticsearch.clusterName={{ .Values.elasticsearch.clusterName }}
     elasticsearch.indexName={{ template "nuxeo.fullname" . }}
     elasticsearch.indexNumberOfReplicas={{ .Values.elasticsearch.indexNumberOfReplicas }}
@@ -39,7 +43,7 @@ data:
 {{- end }}
 {{- if .Values.kafka.enabled }}
     kafka.enabled=true
-    kafka.bootstrap.servers={{ required "kafka.host is required" .Values.kafka.host }}:{{ .Values.kafka.port }}
+    kafka.bootstrap.servers={{ .Values.kafka.host }}:{{ .Values.kafka.port }}
     kafka.topicPrefix={{ template "nuxeo.fullname" . }}
     nuxeo.stream.work.enabled=true
     nuxeo.pubsub.provider=stream

--- a/nuxeo/templates/configmap.yaml
+++ b/nuxeo/templates/configmap.yaml
@@ -51,7 +51,7 @@ data:
 {{- if .Values.redis.enabled }}
 {{- if .Values.mongodb.enabled }}
     nuxeo.templates=default,mongodb,redis
-{{- else if  .Values.postgresql.enabled }}
+{{- else if .Values.postgresql.enabled }}
     nuxeo.templates=default,postgresql,redis
 {{- else }}
     nuxeo.templates=default,redis
@@ -62,7 +62,7 @@ data:
 {{- end }}
 {{- if .Values.googleCloudStorage.enabled }}
     nuxeo.core.binarymanager=org.nuxeo.ecm.core.storage.gcp.GoogleStorageBinaryManager
-    nuxeo.gcp.project={{ .Values.googleCloudStorage.gcpProject }}
+    nuxeo.gcp.project={{ .Values.googleCloudStorage.gcpProjectId }}
     nuxeo.gcp.credentials={{ .Values.googleCloudStorage.credentials }}
     nuxeo.gcp.storage.bucket= {{ .Values.googleCloudStorage.bucket }}
     {{- if .Values.googleCloudStorage.bucketPrefix }}

--- a/nuxeo/templates/configmap.yaml
+++ b/nuxeo/templates/configmap.yaml
@@ -79,6 +79,11 @@ data:
     nuxeo.s3storage.bucket_prefix={{ template "nuxeo.fullname" . }}/
     {{- end }}
 {{- end }}
+    metrics.enabled={{ .Values.metrics.enabled }}
+{{- if .Values.metrics.stackDriver.enabled }}
+    metrics.stackdriver.enabled={{ .Values.metrics.stackDriver.enabled }}
+    metrics.stackdriver.gcpProjectId={{ .Values.metrics.stackDriver.gcpProjectId }}
+{{- end }}
 {{- if or (gt (int .Values.replicaCount) 1) (include "nuxeo.cloudProvider.enabled" .) }}
     nuxeo.cluster.enabled=true
     nuxeo.cluster.nodeid=${env:POD_UID}

--- a/nuxeo/templates/configmap.yaml
+++ b/nuxeo/templates/configmap.yaml
@@ -1,10 +1,18 @@
 {{- $credentials := ternary "" (printf "%s%s" .Values.mongodb.credentials "@") (empty .Values.mongodb.credentials) -}}
+{{- range splitList "," (include "nuxeo.nodeTypes" .) }}
+{{- $nuxeoNodeType := . -}}
+{{- $nuxeoFullnameSuffix := ternary "" (printf "-%s" $nuxeoNodeType) (eq $nuxeoNodeType "single") -}}
+{{- $workerNode := (eq $nuxeoNodeType "worker") -}}
+{{- with $ }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "nuxeo.fullname" . }}-conf
+  name: {{ template "nuxeo.fullname" . }}-conf{{ $nuxeoFullnameSuffix }}
   labels:
     app: {{ template "nuxeo.fullname" . }}
+    nuxeoNode: {{ $nuxeoNodeType }}
+    tier: {{ ternary "backend" "frontend" $workerNode }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -91,6 +99,17 @@ data:
 {{- if or (gt (int .Values.replicaCount) 1) (include "nuxeo.cloudProvider.enabled" .) }}
     nuxeo.cluster.enabled=true
     nuxeo.cluster.nodeid=${env:POD_UID}
+{{- end }}
+{{- if eq $nuxeoNodeType "api" }}
+    # {{ $nuxeoNodeType }} node: disable workers and stream processing
+    nuxeo.stream.processing.enabled=false
+    nuxeo.work.processing.enabled=false
+{{- else }}
+    # {{ $nuxeoNodeType }} node: enable workers and stream processing
+    nuxeo.stream.processing.enabled=true
+    nuxeo.work.processing.enabled=true
+{{- end }}
+{{- end }}
 {{- end }}
 {{- range $key, $val := .Values.customProperties }}
 {{- with $ }}

--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -25,9 +25,12 @@ spec:
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-      {{- with .Values.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- with .Values.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets: {{ toYaml . | nindent 6}}

--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -108,7 +108,7 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
-{{- if .Values.mongodb.enabled }}
+{{- if and .Values.mongodb.enabled .Values.mongodb.host }}
       - name: init-mongodb
         image: busybox
         command: ['sh', '-c', 'until nc -w1 {{ .Values.mongodb.host }} {{ .Values.mongodb.port }}; do echo "waiting for mongodb"; sleep 2; done;']

--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
             path: {{ .Values.probePath }}
@@ -55,7 +55,7 @@ spec:
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -57,6 +57,14 @@ spec:
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.failureThreshold }}
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: POD_UID
           valueFrom:
             fieldRef:

--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -1,18 +1,27 @@
+{{- range splitList "," (include "nuxeo.nodeTypes" .) }}
+{{- $nuxeoNodeType := . -}}
+{{- $nuxeoFullnameSuffix := ternary "" (printf "-%s" $nuxeoNodeType) (eq $nuxeoNodeType "single") -}}
+{{- $workerNode := (eq $nuxeoNodeType "worker") -}}
+{{- with $ }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "nuxeo.fullname" . }}
+  name: {{ template "nuxeo.fullname" . }}{{ $nuxeoFullnameSuffix }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   selector:
     matchLabels:
       app: {{ template "nuxeo.fullname" . }}
-  replicas: {{ .Values.replicaCount }}
+      nuxeoNode: {{ $nuxeoNodeType }}
+  replicas: {{ ternary (default 1 .Values.workerCount) .Values.replicaCount $workerNode }}
   template:
     metadata:
       labels:
         app: {{ template "nuxeo.fullname" . }}
+        nuxeoNode: {{ $nuxeoNodeType }}
+        tier: {{ ternary "backend" "frontend" $workerNode }}
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -133,7 +142,7 @@ spec:
       volumes:
       - name: nuxeoconf
         configMap:
-          name: {{ template "nuxeo.fullname" . }}-conf
+          name: {{ template "nuxeo.fullname" . }}-conf{{ $nuxeoFullnameSuffix }}
       {{- range $key, $val := .Values.customProperties }}
       {{- with $ }}
       - name: nuxeoconf-{{ $key }}
@@ -172,3 +181,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
+{{- end }}

--- a/nuxeo/templates/ingress.yaml
+++ b/nuxeo/templates/ingress.yaml
@@ -23,10 +23,12 @@ spec:
   rules:
     - http:
         paths:
-          - path: {{ .Values.ingress.path }}
-            backend:
+          - backend:
               serviceName: {{ template "nuxeo.fullname" . }}
               servicePort: {{ .Values.service.externalPort}}
+            {{- if .Values.ingress.path }}
+            path: {{ .Values.ingress.path }}
+            {{- end }}
       {{- with .Values.ingress.hostname }}
       host: {{ toYaml . }}
       {{- end }}

--- a/nuxeo/templates/service.yaml
+++ b/nuxeo/templates/service.yaml
@@ -20,3 +20,4 @@ spec:
     name: http
   selector:
     app: {{ template "nuxeo.fullname" . }}
+    tier: frontend

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -41,30 +41,31 @@ readinessProbe:
 # clid:
 mongodb:
   enabled: false
-  protocol: mongodb
-  port: 27017
-  # host:
+  # protocol: mongodb
   # credentials:
+  # url:
+  # host:
+  # port: 27017
 postgresql:
   enabled: false
-  port: 5432
   # host:
+  # port: 5432
   # username:
   # password:
 elasticsearch:
   enabled: false
-  protocol: http
-  port: 9200
-  clusterName: elasticsearch
-  indexNumberOfReplicas: 0
-  restClient:
-    socketTimeoutMs: 300000
-    connectionTimeoutMs: 300000
+  # protocol: http
   # host:
+  # port: 9200
+  # clusterName: elasticsearch
+  # indexNumberOfReplicas: 0
+  # restClient:
+  #   socketTimeoutMs: 300000
+  #   connectionTimeoutMs: 300000
 kafka:
   enabled: false
-  port: 9092
   # host:
+  # port: 9092
 redis:
   enabled: false
 googleCloudStorage:

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -133,6 +133,12 @@ logs:
 ## customEnvsFrom allows to load the content of a ConfigMap as environment variables
 # customEnvsFrom:
 
+metrics:
+  enabled: true
+  stackDriver:
+    enabled: false
+    # gcpProjectId:
+
 extraVolumeMounts: []
 extraVolumes: []
 extraSecrets: {}

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -3,7 +3,14 @@ image:
   tag: latest
   pullSecrets: []
   pullPolicy: Always
+## Nuxeo architecture, among:
+## - singleNode: a single Nuxeo node with workers and stream processing enabled
+## - api-worker:
+##   - `replicaCount` API nodes: handling HTTP requests, with workers and stream processing disabled
+##   - `workerCount` worker nodes: not handling HTTP requests, with workers and stream processing enabled
+architecture: singleNode
 replicaCount: 1
+# workerCount: 1
 clusterDomain: cluster.local
 # virtualHost:
 podLabels: {}

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: docker.packages.nuxeo.com/nuxeo/nuxeo
   tag: latest
   pullSecrets: []
-  pullPolicy: Always
+  # pullPolicy:
 ## Nuxeo architecture, among:
 ## - singleNode: a single Nuxeo node with workers and stream processing enabled
 ## - api-worker:

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -70,7 +70,7 @@ redis:
   enabled: false
 googleCloudStorage:
   enabled: false
-  # gcpProject:
+  # gcpProjectId:
   # credentials:
   # bucket:
   ## The bucket prefix needs to end with /


### PR DESCRIPTION
Note that [01babc4](https://github.com/nuxeo/nuxeo-helm-chart/pull/30/commits/01babc462856fe1c51cc544d21942d066c3468d8) allows to configure a full MongoDB URL with `mongodb.url` (instead of host + port) for the case of a MongoDB ReplicaSet  with several servers.
Yet, in this case, I've disabled the MongoDB `initContainer`, not  knowing how to deal with https://github.com/nuxeo/nuxeo-helm-chart/pull/30/commits/01babc462856fe1c51cc544d21942d066c3468d8#diff-ebc2121f700ad5a2fed2ea63f3bf3729c0d4f1183ce4451adba35dd00447cb06R114.