### PR TITLE
NXBT-3686: Use the appropriate S3 binary manager

### DIFF
--- a/nuxeo/templates/configmap.yaml
+++ b/nuxeo/templates/configmap.yaml
@@ -85,7 +85,7 @@ data:
     {{- end }}
 {{- end }}
 {{- if .Values.amazonS3.enabled }}
-    nuxeo.core.binarymanager=org.nuxeo.ecm.core.storage.sql.S3BinaryManager
+    nuxeo.core.binarymanager=org.nuxeo.ecm.blob.s3.S3BlobProvider
     nuxeo.aws.accessKeyId={{ .Values.amazonS3.accessKeyId }}
     nuxeo.aws.secretKey={{ .Values.amazonS3.secretAccessKey }}
     nuxeo.aws.region={{ .Values.amazonS3.region }}


### PR DESCRIPTION
This is the default binary manager since LTS 2021, and the binary manager exists and is recommended in 2019.