### PR TITLE
Allow securityContext for init containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `mongodb.initContainer.repository` | Image name for MongoDB connection init container                                                                                              | `busybox` |
 | `mongodb.initContainer.tag` | Image tag for MongoDB connection init container                                                                                               | `latest` |
 | `mongodb.initContainer.imagePullPolicy` | Image pull policy for MongoDB connection init container                                                                                       | `IfNotPresent` |
+| `mongodb.initContainer.securityContext` | Security context for MongoDB init container                                                                                       | `{}` |
 | `postgresql.enabled` | Enable PostgreSQL backend for Nuxeo                                                                                                           | `false` |
 | `postgresql.dbName` | PostgreSQL database name                                                                                                                      | `""` |
 | `postgresql.host` | Host for PostgreSQL connection                                                                                                                | `""` |
@@ -302,6 +303,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `postgresql.initContainer.repository` | Image name for PostgreSQL connection init container                                                                                           | `busybox` |
 | `postgresql.initContainer.tag` | Image tag for PostgreSQL connection init container                                                                                            | `latest` |
 | `postgresql.initContainer.imagePullPolicy` | Image pull policy for PostgreSQL connection init container                                                                                    | `IfNotPresent` |
+| `postgresql.initContainer.securityContext` | Security context for PostgreSQL init container                                                                                       | `{}` |
 | `elasticsearch.enabled` | Enable Elasticsearch for Nuxeo                                                                                                                | `false` |
 | `elasticsearch.indexName` | Elasticsearch index name for the default document repository                                                                                  | `""` |
 | `elasticsearch.protocol` | Protocol for Elasticsearch connection                                                                                                         | `http` |
@@ -319,6 +321,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `elasticsearch.initContainer.repository` | Image name for Elasticsearch connection init container                                                                                        | `busybox` |
 | `elasticsearch.initContainer.tag` | Image tag for Elasticsearch connection init container                                                                                         | `latest` |
 | `elasticsearch.initContainer.imagePullPolicy` | Image pull policy for Elasticsearch connection init container                                                                                 | `IfNotPresent` |
+| `elasticsearch.initContainer.securityContext` | Security context for Elasticsearch init container                                                                                       | `{}` |
 | `kafka.enabled` | Enable Kafka for Nuxeo                                                                                                                        | `false` |
 | `kafka.host` | Host for Kafka connection                                                                                                                     | `""` |
 | `kafka.port` | Post for Kafka connection                                                                                                                     | `9092` |
@@ -329,6 +332,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `kafka.initContainer.repository` | Image name for Kafka connection init container                                                                                                | `busybox` |
 | `kafka.initContainer.tag` | Image tag for Kafka connection init container                                                                                                 | `latest` |
 | `kafka.initContainer.imagePullPolicy` | Image pull policy for Kafka connection init container                                                                                         | `IfNotPresent` |
+| `kafka.initContainer.securityContext` | Security context for Kafka init container                                                                                       | `{}` |
 | `redis.enabled` | Enable redis for Nuxeo                                                                                                                        | `false` |
 | `initContainers` | Extra init containers for Nuxeo deployment                                                                                                    | `[]` |
 | `googleCloudStorage.enabled` | Enable Google Cloud Storage for Nuxeo                                                                                                         | `false` |

--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -228,24 +228,36 @@ spec:
         image: "{{ .Values.mongodb.initContainer.repository }}:{{ .Values.mongodb.initContainer.tag }}"
         imagePullPolicy: {{ .Values.mongodb.initContainer.imagePullPolicy }}
         command: ['sh', '-c', 'until nc -w1 {{ .Values.mongodb.host }} {{ .Values.mongodb.port }}; do echo "waiting for mongodb"; sleep 2; done;']
+        {{- with .Values.mongodb.initContainer.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
 {{- end }}
 {{- if .Values.postgresql.enabled }}
       - name: init-postgresql
         image: "{{ .Values.postgresql.initContainer.repository }}:{{ .Values.postgresql.initContainer.tag }}"
         imagePullPolicy: {{ .Values.postgresql.initContainer.imagePullPolicy }}
         command: ['sh', '-c', 'until nc -w1 {{ .Values.postgresql.host }} {{ .Values.postgresql.port }}; do echo "waiting for postgresql"; sleep 2; done;']
+        {{- with .Values.postgresql.initContainer.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
 {{- end }}
 {{- if .Values.elasticsearch.enabled }}
       - name: init-elasticsearch
         image: "{{ .Values.elasticsearch.initContainer.repository }}:{{ .Values.elasticsearch.initContainer.tag }}"
         imagePullPolicy: {{ .Values.elasticsearch.initContainer.imagePullPolicy }}
         command: ['sh', '-c', 'until nc -w1 {{ .Values.elasticsearch.host }} {{ .Values.elasticsearch.port }}; do echo "waiting for elastic"; sleep 2; done;']
+        {{- with .Values.elasticsearch.initContainer.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
 {{- end }}
 {{- if .Values.kafka.enabled }}
       - name: init-kafka
         image: "{{ .Values.kafka.initContainer.repository }}:{{ .Values.kafka.initContainer.tag }}"
         imagePullPolicy: {{ .Values.kafka.initContainer.imagePullPolicy }}
         command: ['sh', '-c', 'until nc -w1 {{ .Values.kafka.host }} {{ .Values.kafka.port }}; do echo "waiting for kafka"; sleep 2; done;']
+        {{- with .Values.kafka.initContainer.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
 {{- end }}
       {{- with .Values.initContainers }}
       {{- toYaml . | nindent 6 }}

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -93,6 +93,7 @@ mongodb:
     repository: busybox
     tag: latest
     imagePullPolicy: IfNotPresent
+    securityContext: {}
 postgresql:
   enabled: false
   dbName: ""
@@ -112,6 +113,7 @@ postgresql:
     repository: busybox
     tag: latest
     imagePullPolicy: IfNotPresent
+    securityContext: {}
 elasticsearch:
   enabled: false
   indexName: ""
@@ -143,6 +145,7 @@ elasticsearch:
     repository: busybox
     tag: latest
     imagePullPolicy: IfNotPresent
+    securityContext: {}
 kafka:
   enabled: false
   host: ""
@@ -159,6 +162,7 @@ kafka:
     repository: busybox
     tag: latest
     imagePullPolicy: IfNotPresent
+    securityContext: {}
 redis:
   enabled: false
 ## Extra init containers.


### PR DESCRIPTION
**Description** 
Add new values securityContext for each initContainers : mongoDB, postgresql, elasticsearch and Kafka. 

**Benefits**
This change allow to give a securityContext to initContainers. Choice was made to allow to set a different context for each initContainer. We do not use podSecurityContext as some fields are only available for the container's securityContext.
