### PR TITLE
NXP-33357: Add support for image digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The following tables lists the configurable parameters of this chart and their d
 | --------- | ----------- | ------- |
 | `image.repository` | Nuxeo image name | `docker-private.packages.nuxeo.com/nuxeo/nuxeo` |
 | `image.tag` | Nuxeo image tag | `2023` |
-| `image.digest` | Nuxeo image digest in the form `sha256:...`. When set, takes precedence over `image.tag` and the image is referenced as `repository@digest`. | `""` |
+| `image.digest` | Nuxeo image digest in the form `sha256:...`. When set, takes precedence over `image.tag` for the image pull reference (`repository@digest`). The `image.tag` is still used as the `app.kubernetes.io/version` label; if empty, the label falls back to the first 12 hex characters of the digest. | `""` |
 | `image.pullSecrets` | Nuxeo image registry secret names | `[]` |
 | `image.pullPolicy` | Nuxeo image pull policy | `IfNotPresent` |
 | `architecture` | Nuxeo architecture (`singleNode` or `api-worker`) | `singleNode` |

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ The following tables lists the configurable parameters of this chart and their d
 | --------- | ----------- | ------- |
 | `image.repository` | Nuxeo image name | `docker-private.packages.nuxeo.com/nuxeo/nuxeo` |
 | `image.tag` | Nuxeo image tag | `2023` |
+| `image.digest` | Nuxeo image digest in the form `sha256:...`. When set, takes precedence over `image.tag` and the image is referenced as `repository@digest`. | `""` |
 | `image.pullSecrets` | Nuxeo image registry secret names | `[]` |
 | `image.pullPolicy` | Nuxeo image pull policy | `IfNotPresent` |
 | `architecture` | Nuxeo architecture (`singleNode` or `api-worker`) | `singleNode` |
@@ -300,6 +301,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `mongodb.auth.existingSecret` | Existing secret with MongoDB credentials (keys: `mongodb-username`, `mongodb-password`), overrides `username` and `password` | `""` |
 | `mongodb.initContainer.repository` | Image name for MongoDB connection init container | `busybox` |
 | `mongodb.initContainer.tag` | Image tag for MongoDB connection init container | `latest` |
+| `mongodb.initContainer.digest` | Image digest in the form `sha256:...` for MongoDB connection init container. When set, takes precedence over `tag`. | `""` |
 | `mongodb.initContainer.imagePullPolicy` | Image pull policy for MongoDB connection init container | `IfNotPresent` |
 | `mongodb.initContainer.securityContext` | Security context for MongoDB init container | `{}` |
 | `postgresql.enabled` | Enable PostgreSQL backend for Nuxeo | `false` |
@@ -311,6 +313,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `postgresql.auth.existingSecret` | Existing secret with PostgreSQL credentials (keys: `postgresql-username`, `postgresql-password`), overrides `username` and `password` | `""` |
 | `postgresql.initContainer.repository` | Image name for PostgreSQL connection init container | `busybox` |
 | `postgresql.initContainer.tag` | Image tag for PostgreSQL connection init container | `latest` |
+| `postgresql.initContainer.digest` | Image digest in the form `sha256:...` for PostgreSQL connection init container. When set, takes precedence over `tag`. | `""` |
 | `postgresql.initContainer.imagePullPolicy` | Image pull policy for PostgreSQL connection init container | `IfNotPresent` |
 | `postgresql.initContainer.securityContext` | Security context for PostgreSQL init container | `{}` |
 | `elasticsearch.enabled` | Enable Elasticsearch for Nuxeo | `false` |
@@ -329,6 +332,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `elasticsearch.httpReadOnly.enabled` | Enable Elasticsearch passthrough | `false` |
 | `elasticsearch.initContainer.repository` | Image name for Elasticsearch connection init container | `busybox` |
 | `elasticsearch.initContainer.tag` | Image tag for Elasticsearch connection init container | `latest` |
+| `elasticsearch.initContainer.digest` | Image digest in the form `sha256:...` for Elasticsearch connection init container. When set, takes precedence over `tag`. | `""` |
 | `elasticsearch.initContainer.imagePullPolicy` | Image pull policy for Elasticsearch connection init container | `IfNotPresent` |
 | `elasticsearch.initContainer.securityContext` | Security context for Elasticsearch init container | `{}` |
 | `kafka.enabled` | Enable Kafka for Nuxeo | `false` |
@@ -340,6 +344,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `kafka.auth.existingSecret` | Existing secret with Kafka credentials (keys: `kafka-username`, `kafka-password`), overrides `username` and `password` | `""` |
 | `kafka.initContainer.repository` | Image name for Kafka connection init container | `busybox` |
 | `kafka.initContainer.tag` | Image tag for Kafka connection init container | `latest` |
+| `kafka.initContainer.digest` | Image digest in the form `sha256:...` for Kafka connection init container. When set, takes precedence over `tag`. | `""` |
 | `kafka.initContainer.imagePullPolicy` | Image pull policy for Kafka connection init container | `IfNotPresent` |
 | `kafka.initContainer.securityContext` | Security context for Kafka init container | `{}` |
 | `redis.enabled` | Enable redis for Nuxeo | `false` |

--- a/nuxeo/templates/NOTES.txt
+++ b/nuxeo/templates/NOTES.txt
@@ -1,6 +1,6 @@
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
-APP VERSION: {{ .Values.image.tag }}
+IMAGE: {{ include "nuxeo.image.ref" .Values.image }}
 
 {{- include "nuxeo.validateValues" . }}
 

--- a/nuxeo/templates/_helpers.tpl
+++ b/nuxeo/templates/_helpers.tpl
@@ -46,6 +46,21 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Return a container image reference string.
+Uses `repository@digest` when `digest` is set, otherwise `repository:tag`.
+Scope: a dict with `repository`, `tag`, `digest` keys
+(e.g., .Values.image or .Values.mongodb.initContainer).
+*/}}
+{{- define "nuxeo.image.ref" -}}
+{{- $img := . -}}
+{{- if $img.digest -}}
+{{ $img.repository }}@{{ $img.digest }}
+{{- else -}}
+{{ $img.repository }}:{{ $img.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "nuxeo.labels" -}}

--- a/nuxeo/templates/_helpers.tpl
+++ b/nuxeo/templates/_helpers.tpl
@@ -61,6 +61,19 @@ Scope: a dict with `repository`, `tag`, `digest` keys
 {{- end -}}
 
 {{/*
+Return a Kubernetes-label-safe version string.
+Uses image.tag if set, otherwise the first 12 hex chars of image.digest
+(strips any algorithm prefix like "sha256:" or "sha512:").
+*/}}
+{{- define "nuxeo.image.version" -}}
+{{- if .Values.image.tag -}}
+{{ .Values.image.tag | toString }}
+{{- else -}}
+{{ last (splitList ":" (.Values.image.digest | toString)) | trunc 12 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "nuxeo.labels" -}}
@@ -69,7 +82,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- with .nuxeoNodeType }}
 app.kubernetes.io/component: {{ . }}
 {{- end }}
-app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+app.kubernetes.io/version: {{ include "nuxeo.image.version" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "nuxeo.chart" . }}
 {{ include "nuxeo.selectorLabels" . }}
@@ -91,9 +104,12 @@ tier: {{ ternary "backend" "frontend" (eq (default "single" .nuxeoNodeType) "wor
 
 {{/*
 Return true if the deployment needs to be rolled.
+A digest-pinned image is immutable, so no roll is needed.
 */}}
 {{- define "nuxeo.deployment.roll" -}}
-{{- if .Values.image.pullPolicy -}}
+{{- if .Values.image.digest -}}
+  {{- false -}}
+{{- else if .Values.image.pullPolicy -}}
   {{- if eq "Always" .Values.image.pullPolicy -}}
     {{- true -}}
   {{- else -}}

--- a/nuxeo/templates/_warnings.tpl
+++ b/nuxeo/templates/_warnings.tpl
@@ -94,7 +94,7 @@ WARNING
 {{- end -}}
 
 {{- define "nuxeo.warnings.message.rolling-tag" -}}
-{{- if and (contains "/nuxeo/nuxeo" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "^(\\d)+\\.(\\d)+.*$" )) }}
+{{- if and (contains "/nuxeo/nuxeo" .Values.image.repository) (not .Values.image.digest) (not (.Values.image.tag | toString | regexFind "^(\\d)+\\.(\\d)+.*$" )) }}
   Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}),
   please note that it is strongly recommended to avoid using rolling tags
   in a production environment.

--- a/nuxeo/templates/deployment.yaml
+++ b/nuxeo/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- with .Values.resources }}
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ include "nuxeo.image.ref" .Values.image | quote }}
         {{- with .Values.image.pullPolicy }}
         imagePullPolicy: {{ toYaml . }}
         {{- end }}
@@ -225,7 +225,7 @@ spec:
       initContainers:
 {{- if and .Values.mongodb.enabled .Values.mongodb.host }}
       - name: init-mongodb
-        image: "{{ .Values.mongodb.initContainer.repository }}:{{ .Values.mongodb.initContainer.tag }}"
+        image: {{ include "nuxeo.image.ref" .Values.mongodb.initContainer | quote }}
         imagePullPolicy: {{ .Values.mongodb.initContainer.imagePullPolicy }}
         command: ['sh', '-c', 'until nc -w1 {{ .Values.mongodb.host }} {{ .Values.mongodb.port }}; do echo "waiting for mongodb"; sleep 2; done;']
         {{- with .Values.mongodb.initContainer.securityContext }}
@@ -234,7 +234,7 @@ spec:
 {{- end }}
 {{- if .Values.postgresql.enabled }}
       - name: init-postgresql
-        image: "{{ .Values.postgresql.initContainer.repository }}:{{ .Values.postgresql.initContainer.tag }}"
+        image: {{ include "nuxeo.image.ref" .Values.postgresql.initContainer | quote }}
         imagePullPolicy: {{ .Values.postgresql.initContainer.imagePullPolicy }}
         command: ['sh', '-c', 'until nc -w1 {{ .Values.postgresql.host }} {{ .Values.postgresql.port }}; do echo "waiting for postgresql"; sleep 2; done;']
         {{- with .Values.postgresql.initContainer.securityContext }}
@@ -243,7 +243,7 @@ spec:
 {{- end }}
 {{- if .Values.elasticsearch.enabled }}
       - name: init-elasticsearch
-        image: "{{ .Values.elasticsearch.initContainer.repository }}:{{ .Values.elasticsearch.initContainer.tag }}"
+        image: {{ include "nuxeo.image.ref" .Values.elasticsearch.initContainer | quote }}
         imagePullPolicy: {{ .Values.elasticsearch.initContainer.imagePullPolicy }}
         command: ['sh', '-c', 'until nc -w1 {{ .Values.elasticsearch.host }} {{ .Values.elasticsearch.port }}; do echo "waiting for elastic"; sleep 2; done;']
         {{- with .Values.elasticsearch.initContainer.securityContext }}
@@ -252,7 +252,7 @@ spec:
 {{- end }}
 {{- if .Values.kafka.enabled }}
       - name: init-kafka
-        image: "{{ .Values.kafka.initContainer.repository }}:{{ .Values.kafka.initContainer.tag }}"
+        image: {{ include "nuxeo.image.ref" .Values.kafka.initContainer | quote }}
         imagePullPolicy: {{ .Values.kafka.initContainer.imagePullPolicy }}
         command: ['sh', '-c', 'until nc -w1 {{ .Values.kafka.host }} {{ .Values.kafka.port }}; do echo "waiting for kafka"; sleep 2; done;']
         {{- with .Values.kafka.initContainer.securityContext }}

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -2,7 +2,10 @@ image:
   repository: docker-private.packages.nuxeo.com/nuxeo/nuxeo
   tag: 2023
   # Image digest in the form `sha256:...`. When set, takes precedence over `tag`
-  # and the image is referenced as `repository@digest` (immutable pin).
+  # for the image pull reference (rendered as `repository@digest`).
+  # The `tag` value is still used as the `app.kubernetes.io/version` label for
+  # human-readable identification; if `tag` is empty, the label falls back to
+  # the first 12 hex characters of the digest.
   digest: ""
   pullSecrets: []
   pullPolicy: IfNotPresent

--- a/nuxeo/values.yaml
+++ b/nuxeo/values.yaml
@@ -1,6 +1,9 @@
 image:
   repository: docker-private.packages.nuxeo.com/nuxeo/nuxeo
   tag: 2023
+  # Image digest in the form `sha256:...`. When set, takes precedence over `tag`
+  # and the image is referenced as `repository@digest` (immutable pin).
+  digest: ""
   pullSecrets: []
   pullPolicy: IfNotPresent
 ## Nuxeo architecture, among:
@@ -94,6 +97,8 @@ mongodb:
   initContainer:
     repository: busybox
     tag: latest
+    # Image digest in the form `sha256:...`. When set, takes precedence over `tag`.
+    digest: ""
     imagePullPolicy: IfNotPresent
     securityContext: {}
 postgresql:
@@ -114,6 +119,8 @@ postgresql:
   initContainer:
     repository: busybox
     tag: latest
+    # Image digest in the form `sha256:...`. When set, takes precedence over `tag`.
+    digest: ""
     imagePullPolicy: IfNotPresent
     securityContext: {}
 elasticsearch:
@@ -146,6 +153,8 @@ elasticsearch:
   initContainer:
     repository: busybox
     tag: latest
+    # Image digest in the form `sha256:...`. When set, takes precedence over `tag`.
+    digest: ""
     imagePullPolicy: IfNotPresent
     securityContext: {}
 kafka:
@@ -163,6 +172,8 @@ kafka:
   initContainer:
     repository: busybox
     tag: latest
+    # Image digest in the form `sha256:...`. When set, takes precedence over `tag`.
+    digest: ""
     imagePullPolicy: IfNotPresent
     securityContext: {}
 redis:


### PR DESCRIPTION
## NXP-33357: Add support for image digest

Jira: [NXP-33357](https://hyland.atlassian.net/browse/NXP-33357)

### Motivation

In environments with strict security and compliance requirements — such as those using image digest pinning to ensure immutability and reproducibility — being able to set `image.digest` is crucial. Many official Helm charts (Bitnami and others) support this pattern, typically allowing either `tag` or `digest` (or both) to be defined.

### Changes

- Add an optional `digest` value to the main Nuxeo image block and to each of the 4 init-container blocks (`mongodb`, `postgresql`, `elasticsearch`, `kafka`).
- When `digest` is set, the image is rendered as `repository@digest` (immutable pin) and `tag` is silently dropped from the reference. When `digest` is empty, the existing `repository:tag` rendering is preserved.
- Introduce a generic `nuxeo.image.ref` helper that builds the image reference string from a dict of `repository`/`tag`/`digest`, and use it for all 5 image references in the Deployment.
- Suppress the rolling-tag warning when `image.digest` is set, since digest pinning is stronger than tag pinning.
- Document the new `*.digest` parameters in `README.md`.

### Backward compatibility

Fully backward compatible: `digest` defaults to `""` for all 5 blocks. The default `helm template` render is byte-identical to `master`.

### Verification

- `helm lint nuxeo` — clean.
- `helm template nuxeo nuxeo` (defaults) — byte-identical to `master`.
- `helm template ... --set image.digest=sha256:...` — renders `repository@digest`, tag dropped.
- `helm template ... --set image.tag=latest --set image.digest=sha256:...` — digest wins; rolling-tag warning is suppressed.
- `helm template ... --set image.tag=latest` (no digest) — rolling-tag warning still fires.
- All 4 init containers honor `digest` independently.

[NXP-33357]: https://hyland.atlassian.net/browse/NXP-33357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ